### PR TITLE
In UDP mode, messages are truncated

### DIFF
--- a/protolog/loglistener.go
+++ b/protolog/loglistener.go
@@ -99,9 +99,9 @@ func (ll *LogListener) startUDP(proto string, address string) {
 	defer l.Close()
 
 	logp.Info("Now listening for logs via %s on %s", ll.config.Protocol, address)
-	buffer := make([]byte, ll.config.MaxMsgSize)
 
 	for {
+		buffer := make([]byte, ll.config.MaxMsgSize)
 		length, _, err := l.ReadFrom(buffer)
 		if err != nil {
 			logp.Err("Error reading from buffer: %v", err.Error())


### PR DESCRIPTION
In startUDP, the buffer has to be created inside the for loop, otherwise processMessage will always get the same buffer (and the content could change before the processMessage goroutine is executed).