### PR TITLE
Feat: parsing gelf levels to be human readable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	ValidateAllJSONTypes   bool              `config:"validate_all_json_types"`
 	JsonSchema             map[string]string `config:"json_schema"`
 	Debug                  bool              `config:"debug"`
+	ParseGelfLevels        bool              `config:"parse_gelf_levels"`
 }
 
 var DefaultConfig = Config{

--- a/protologbeat.full.yml
+++ b/protologbeat.full.yml
@@ -10,6 +10,7 @@ protologbeat:
   #port: 5000
   
   # Protocol on which to listen
+  # This has no action if gelf is enabled
   #protocol: udp
   
   # Maxium message size in bytes
@@ -29,6 +30,9 @@ protologbeat:
   
   # Set process to receive only GELF formated messages
   #enable_gelf: false
+
+  # Parse gelf level to be human readable (6 => "info")
+  # parse_gelf_levels: false
 
   # Enable json validation with schemas
   #enable_json_validation: false


### PR DESCRIPTION
fix  tcp/udp/gel listener logic
If Protocol was set to tcp and enable_gelf was set to true tcp listener
started and no gelf parcing was produced